### PR TITLE
Add required composer fields to satisfy composer validate

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -1,6 +1,7 @@
 {
 	"name": "planet4-luxembourg/planet4-luxembourg",
-
+	"description": "Greenpeace P4 Luxembourg",
+	"license": "MIT",
 	"require": {
 		"greenpeace/planet4-child-theme-luxembourg" : "1.30.6",
 		"greenpeace/planet4-plugin-migrated-urls": "0.0.1"


### PR DESCRIPTION
See: https://circleci.com/gh/greenpeace/planet4-luxembourg/374

```
composer-local.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
require.greenpeace/planet4-child-theme-luxembourg : exact version constraints (1.30.6) should be avoided if the package follows semantic versioning
Exited with code 2
```